### PR TITLE
Fixed the filter code

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ var called = false;
 var waitingFor = 0;
 var asyncTimeoutMs = 10000;
 
-var events = [];
-var filters = [];
+var events = {};
+var filters = {};
 
 function exit(exit, code, err) {
 	// Only execute hooks once
@@ -106,8 +106,9 @@ function add(hook) {
 // New signal / event to hook
 add.hookEvent = function (event, code, filter) {
 	events[event] = function () {
-		for (var i = 0; i < filters.length; i++) {
-			if (filters[i].apply(this, arguments)) {
+		const eventFilters = filters[event];
+		for (var i = 0; i < eventFilters.length; i++) {
+			if (eventFilters[i].apply(this, arguments)) {
 				return;
 			}
 		}


### PR DESCRIPTION
Couldn't file an issue for whatever reason, but here is the fix. I was using async-exit-hook in a child process, which would mysteriously terminate on any message.

Using arrays as maps/objects ensures `length` property is never useful, so the for loop didn't run, so `exit` was called on the first message.
I changed both `events` and `filters` to objects to remove the confusion about their usage. I wanted to add a test for this change but I have a hard time grokking the test suite in the time I can spend on this.