### PR TITLE
Add unhandledRejectionHandler

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,6 @@ add.uncaughtExceptionHandler = function (hook) {
 	}
 };
 
-
 // Add an unhandled rejection handler
 add.unhandledRejectionHandler = function (hook) {
 	errHooks.push(hook);

--- a/index.js
+++ b/index.js
@@ -149,6 +149,15 @@ add.uncaughtExceptionHandler = function (hook) {
 
 	if (errHooks.length === 1) {
 		process.once('uncaughtException', exit.bind(null, true, 1));
+	}
+};
+
+
+// Add an unhandled rejection handler
+add.unhandledRejectionHandler = function (hook) {
+	errHooks.push(hook);
+
+	if (errHooks.length === 1) {
 		process.once('unhandledRejection', exit.bind(null, true, 1));
 	}
 };

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,11 @@ exitHook.uncaughtExceptionHandler(err => {
     console.error(err);
 });
 
+// You can hook unhandled rejections with unhandledRejectionHandler()
+exitHook.uncaughtExceptionHandler(err => {
+    console.error(err);
+});
+
 // You can add multiple uncaught error handlers
 // Add the second parameter (callback) to indicate async hooks
 exitHook.uncaughtExceptionHandler((err, callback) => {

--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@ exitHook.uncaughtExceptionHandler(err => {
 });
 
 // You can hook unhandled rejections with unhandledRejectionHandler()
-exitHook.uncaughtExceptionHandler(err => {
+exitHook.unhandledRejectionHandler(err => {
     console.error(err);
 });
 

--- a/test/cases/unhandled-promise.js
+++ b/test/cases/unhandled-promise.js
@@ -14,13 +14,13 @@ exitHook(function () {
 	stub.called();
 });
 
-exitHook.uncaughtExceptionHandler(function (err, cb) {
+exitHook.unhandledRejectionHandler(function (err, cb) {
 	setTimeout(function () {
 		stub.called();
 		cb();
 	}, 50);
 	if (!err || err.message !== 'test-promise') {
-		stub.reject(`No error passed to uncaughtExceptionHandler, or message not test-promise - ${err.message}`);
+		stub.reject(`No error passed to unhandledRejectionHandler, or message not test-promise - ${err.message}`);
 	}
 	stub.called();
 });


### PR DESCRIPTION
Unhandled rejections shouldn't be handled in the same callback of uncaught exceptions for 2 main reasons:
1) It's undocumented!!!
2) Users cannot easly distinguish them

This PR solves the problem adding another dedicated handler function