### PR TITLE
Fix in example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ console.log('Sent err to cloud');
         .catch(sendError => {
 console.error('Error sending to cloud: ', err.stack);
         })
-        .then(() => callback);
+        .then(callback);
 });
 
 // Add exit hooks for a signal or custom message:


### PR DESCRIPTION
I think it's mistake because in your example the final `then()` will call arrow function and will return callback but it should call the callback